### PR TITLE
Remove trace-specific validation for update test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Pelion E2E Python Test Library Changelog
 
+## 0.2.10 2021-03-04
+- Update test doesn't depend on mbed bootloader anymore
+
 ## 0.2.9  2021-01-15
 - Updated instructions
 - Updated python dependencies

--- a/tests/dev-client-tests.py
+++ b/tests/dev-client-tests.py
@@ -122,6 +122,6 @@ def test_05_factory_reset(cloud, client, websocket, api_key):
 
 def test_06_update_device(cloud, client, update_device):
     campaign_id = update_device
-    wait_for_campaign_state(cloud, campaign_id)
+    wait_for_campaign_state(cloud, campaign_id, timeout=UPDATE_TIMEOUT)
     client_id = client.endpoint_id(120)
     wait_for_campaign_device_state(cloud, campaign_id, client_id)

--- a/tests/dev-client-tests.py
+++ b/tests/dev-client-tests.py
@@ -122,7 +122,6 @@ def test_05_factory_reset(cloud, client, websocket, api_key):
 
 def test_06_update_device(cloud, client, update_device):
     campaign_id = update_device
-    client.wait_for_output('New active firmware is valid', timeout=UPDATE_TIMEOUT)
-    client_id = client.endpoint_id(120)
     wait_for_campaign_state(cloud, campaign_id)
+    client_id = client.endpoint_id(120)
     wait_for_campaign_device_state(cloud, campaign_id, client_id)


### PR DESCRIPTION
To have platform agnostic implementation, we should not depend on Mbed bootloader specific tracing.
    
The test will wait for campaign to to autostop, and will then verify the device status to be deployed.
